### PR TITLE
initial move to addons: maas and postgresql

### DIFF
--- a/maas/Chart.yaml
+++ b/maas/Chart.yaml
@@ -1,0 +1,17 @@
+# Copyright 2017 The Openstack-Helm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+description: Chart to run MaaS
+name: maas
+version: 0.1.0

--- a/maas/README.md
+++ b/maas/README.md
@@ -1,0 +1,62 @@
+# aic-helm/maas
+
+This chart installs a working version of MaaS on kubernetes.
+
+### Quickstart
+
+This chart requires a postgresql instance to be running.  
+
+To install postgresql:
+
+```
+helm install postgresql --namespace=maas
+```
+
+Note: Postgresql may take a short time to reach the 'Running' state.  Verify that postgresql is running:
+
+```
+# kubectl get pods -n maas
+NAME                         READY     STATUS        RESTARTS   AGE
+postgresql-0                 1/1       Running       0          1m
+```
+
+To deploy your MaaS chart:
+
+```
+helm install maas --namespace=maas
+```
+
+To verify the helm deployment was successful:
+```
+# helm ls
+NAME         	REVISION	UPDATED                 	STATUS  	CHART           
+opining-mule 	1       	Mon Feb 13 22:20:08 2017	DEPLOYED	maas-0.1.0      
+sweet-manatee	1       	Mon Feb 13 21:57:41 2017	DEPLOYED	postgresql-0.1.0
+
+```
+
+To check that all resources are working as intended:
+```
+# kubectl get all --namespace=maas
+NAME                            READY     STATUS    RESTARTS   AGE
+po/maas-rack-3238195061-tn5fv   1/1       Running   0          11m
+po/maas-region-0                1/1       Running   0          11m
+po/postgresql-0                 1/1       Running   0          34m
+
+NAME                 CLUSTER-IP       EXTERNAL-IP   PORT(S)           AGE
+svc/maas-region-ui   10.105.136.244   <none>        80/TCP,8000/TCP   11m
+svc/postgresql       10.107.159.38    <none>        5432/TCP          34m
+
+NAME                       DESIRED   CURRENT   AGE
+statefulsets/maas-region   1         1         11m
+statefulsets/postgresql    1         1         34m
+
+NAME                           DESIRED   SUCCESSFUL   AGE
+jobs/region-import-resources   1         1            11m
+
+NAME               DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
+deploy/maas-rack   1         1         1            1           11m
+
+NAME                      DESIRED   CURRENT   READY     AGE
+rs/maas-rack-3238195061   1         1         1         11m
+```

--- a/maas/requirements.yaml
+++ b/maas/requirements.yaml
@@ -1,0 +1,18 @@
+# Copyright 2017 The Openstack-Helm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+dependencies:
+  - name: helm-toolkit
+    repository: http://localhost:8879/charts
+    version: 0.1.0

--- a/maas/templates/bin/_import-boot-resources.sh.tpl
+++ b/maas/templates/bin/_import-boot-resources.sh.tpl
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+# Copyright 2017 The Openstack-Helm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+function check_for_download {
+
+    TIMEOUT={{ .Values.jobs.import_boot_resources.timeout }}
+    while [[ ${TIMEOUT} -gt 0 ]]; do
+        if maas {{ .Values.credentials.admin_username }} boot-resources read | grep -q '\[\]';
+        then
+            echo 'Did not find boot resources.  Will try again'
+            let TIMEOUT-={{ .Values.jobs.import_boot_resources.retry_timer }}
+            sleep {{ .Values.jobs.import_boot_resources.retry_timer }}
+        else
+            echo 'Boot resources found'
+            exit 0
+        fi
+    done
+    exit 1
+}
+
+maas-region local_config_set \
+        --database-host "{{ include "helm-toolkit.postgresql_host" . }}" \
+        --database-name "{{ .Values.database.db_name }}" \
+        --database-user "{{ .Values.database.db_user }}" \
+        --database-pass "{{ .Values.database.db_password }}" \
+        --maas-url "http://{{ .Values.ui_service_name }}.{{ .Release.Namespace }}:{{ .Values.network.port.service_gui }}/MAAS"
+
+KEY=$(maas-region apikey --username={{ .Values.credentials.admin_username }})
+maas login {{ .Values.credentials.admin_username }} http://{{ .Values.ui_service_name }}.{{ .Release.Namespace }}/MAAS/ $KEY
+
+# make call to import images
+maas {{ .Values.credentials.admin_username }} boot-resources import
+# see if we can find > 0 images
+sleep {{ .Values.jobs.import_boot_resources.retry_timer }}
+check_for_download

--- a/maas/templates/bin/_job-readiness.sh.tpl
+++ b/maas/templates/bin/_job-readiness.sh.tpl
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Copyright 2017 The Openstack-Helm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+</dev/tcp/{{ .Values.ui_service_name }}.{{ .Release.Namespace }}/{{ .Values.network.port.service_gui }} && \
+</dev/tcp/{{ .Values.db_service_name }}.{{ .Release.Namespace }}/{{ .Values.network.port.db_service }} && \
+pg_isready -h {{ .Values.db_service_name }}.{{ .Release.Namespace }} && \
+maas-region apikey --username={{ .Values.credentials.admin_username }} || exit 1

--- a/maas/templates/bin/_maas-region-controller.postinst.tpl
+++ b/maas/templates/bin/_maas-region-controller.postinst.tpl
@@ -1,0 +1,129 @@
+#!/bin/sh
+
+# Copyright 2017 The Openstack-Helm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+. /usr/share/debconf/confmodule
+db_version 2.0
+
+if [ -f /usr/share/dbconfig-common/dpkg/postinst.pgsql ]; then
+    . /usr/share/dbconfig-common/dpkg/postinst.pgsql
+fi
+
+RELEASE=`lsb_release -rs` || RELEASE=""
+
+maas_sync_migrate_db(){
+    maas-region dbupgrade
+}
+
+restart_postgresql(){
+    invoke-rc.d --force postgresql restart || true
+}
+
+configure_maas_default_url() {
+    local ipaddr="$1"
+    # The given address is either "[IPv6_IP]" or "IPv4_IP" or "name", such as
+    # [2001:db8::3:1]:5555 or 127.0.0.1 or maas.example.com.
+    # The ugly sed splits the given thing as:
+    #   (string of anything but ":", or [ipv6_ip]),
+    #   optionally followed by :port.
+    local address=$(echo "$ipaddr" |
+        sed -rn 's/^([^:]*|\[[0-9a-fA-F:]*\])(|:[0-9]*)?$/\1/p')
+    local port=$(echo "$ipaddr" |
+        sed -rn 's/^([^:]*|\[[0-9a-fA-F:]*\])(|:[0-9]*)?$/\2/p')
+    test -n "$port" || port=":80"
+    ipaddr="${ipaddr}${port}"
+    maas-region local_config_set --maas-url "http://${ipaddr}/MAAS"
+}
+
+extract_default_maas_url() {
+    # Extract DEFAULT_MAAS_URL IP/host setting from config file $1.
+    grep "^DEFAULT_MAAS_URL" "$1" | cut -d"/" -f3
+}
+
+configure_migrate_maas_dns() {
+    # This only runs on upgrade. We only run this if the
+    # there are forwarders to migrate or no
+    # named.conf.options.inside.maas are present.
+    maas-region edit_named_options \
+        --migrate-conflicting-options --config-path \
+        /etc/bind/named.conf.options
+    invoke-rc.d bind9 restart || true
+}
+
+if [ "$1" = "configure" ] && [ -z "$2" ]; then
+    #########################################################
+    ##########  Configure DEFAULT_MAAS_URL  #################
+    #########################################################
+
+    # Obtain IP address of default route and change DEFAULT_MAAS_URL
+    # if default-maas-url has not been preseeded.  Prefer ipv4 addresses if
+    # present, and use "localhost" only if there is no default route in either
+    # address family.
+    db_get maas/default-maas-url
+    ipaddr="$RET"
+    if [ -z "$ipaddr" ]; then
+        ipaddr="{{ .Values.ui_service_name }}.{{ .Release.Namespace }}"
+    fi
+    # Set the IP address of the interface with default route
+    configure_maas_default_url "$ipaddr"
+    db_subst maas/installation-note MAAS_URL "$ipaddr"
+    db_set maas/default-maas-url "$ipaddr"
+
+    #########################################################
+    ################  Configure Database  ###################
+    #########################################################
+
+    # Create the database
+    dbc_go maas-region-controller $@
+    maas-region local_config_set \
+        --database-host {{ include "helm-toolkit.postgresql_host" . | quote }} \
+        --database-name {{ .Values.database.db_name | quote }} \
+        --database-user {{ .Values.database.db_user | quote }} \
+        --database-pass {{ .Values.database.db_password | quote }}
+
+    # Only syncdb if we have selected to install it with dbconfig-common.
+    db_get maas-region-controller/dbconfig-install
+    if [ "$RET" = "true" ]; then
+        maas_sync_migrate_db
+        configure_migrate_maas_dns
+    fi
+
+    db_get maas/username
+    username="$RET"
+    if [ -n "$username" ]; then
+        db_get maas/password
+        password="$RET"
+        if [ -n "$password" ]; then
+            maas-region createadmin --username "$username" --password "$password" --email "$username@maas"
+        fi
+    fi
+
+    # Display installation note
+    db_input low maas/installation-note || true
+    db_go
+
+fi
+
+systemctl enable maas-regiond >/dev/null || true
+systemctl restart maas-regiond >/dev/null || true
+invoke-rc.d apache2 restart || true
+
+if [ -f /lib/systemd/system/maas-rackd.service ]; then
+    systemctl restart maas-rackd >/dev/null || true
+fi
+
+db_stop

--- a/maas/templates/bin/_register-rack-controller.sh.tpl
+++ b/maas/templates/bin/_register-rack-controller.sh.tpl
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Copyright 2017 The Openstack-Helm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+# show env
+env > /tmp/env
+
+echo "register-rack-controller URL: "{{ .Values.ui_service_name }}.{{ .Release.Namespace }}
+
+# note the secret must be a valid hex value
+
+# register forever
+while [ 1 ];
+do
+	if maas-rack register --url=http://{{ .Values.ui_service_name }}.{{ .Release.Namespace }}/MAAS --secret={{ .Values.secret | quote }};
+	then
+		echo "Successfully registered with MaaS Region Controller"
+		break
+	else
+		echo "Unable to register with http://{{ .Values.ui_service_name }}.{{ .Release.Namespace }}/MAAS... will try again"
+		sleep 10
+	fi;
+
+done;

--- a/maas/templates/bin/_start.sh.tpl
+++ b/maas/templates/bin/_start.sh.tpl
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Copyright 2017 The Openstack-Helm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+echo 'running postinst'
+
+chmod 755 /var/lib/dpkg/info/maas-region-controller.postinst
+/bin/sh /var/lib/dpkg/info/maas-region-controller.postinst configure
+
+maas-region createadmin --username={{ .Values.credentials.admin_username }} --password={{ .Values.credentials.admin_password }} --email={{ .Values.credentials.admin_email }} || true

--- a/maas/templates/configmap-bin.yaml
+++ b/maas/templates/configmap-bin.yaml
@@ -1,0 +1,29 @@
+# Copyright 2017 The Openstack-Helm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: maas-bin
+data:
+  start.sh: |
+{{ tuple "bin/_start.sh.tpl" . | include "helm-toolkit.template" | indent 4 }}
+  maas-region-controller.postinst: |
+{{ tuple "bin/_maas-region-controller.postinst.tpl" . | include "helm-toolkit.template" | indent 4 }}
+  import-boot-resources.sh: |
+{{ tuple "bin/_import-boot-resources.sh.tpl" . | include "helm-toolkit.template" | indent 4 }}
+  job-readiness.sh: |
+{{ tuple "bin/_job-readiness.sh.tpl" . | include "helm-toolkit.template" | indent 4 }}
+  register-rack-controller.sh: |
+{{ tuple "bin/_register-rack-controller.sh.tpl" . | include "helm-toolkit.template" | indent 4 }}

--- a/maas/templates/configmap-etc.yaml
+++ b/maas/templates/configmap-etc.yaml
@@ -1,0 +1,25 @@
+# Copyright 2017 The Openstack-Helm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: maas-etc
+data:
+  named.conf.options: |+
+{{ tuple "etc/_region-dns-config.tpl" . | include "helm-toolkit.template" | indent 4 }}
+  secret: |
+{{ tuple "etc/_secret.tpl" . | include "helm-toolkit.template" | indent 4 }}
+  maas-region-controller.conf: |
+{{ tuple "etc/_postgresql-config.tpl" . | include "helm-toolkit.template" | indent 4 }}

--- a/maas/templates/deploy-rack.yaml
+++ b/maas/templates/deploy-rack.yaml
@@ -1,0 +1,52 @@
+# Copyright 2017 The Openstack-Helm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: maas-rack
+spec:
+  template:
+    metadata:
+      labels:
+        app: maas-rack-controller
+    spec:
+      nodeSelector:
+        {{ .Values.labels.node_selector_key }}: {{ .Values.labels.node_selector_value }}
+      hostNetwork: true
+      dnsPolicy: ClusterFirst
+      containers:
+      - name: maas-rack
+        image: {{ .Values.images.maas_rack }}
+        imagePullPolicy: {{ .Values.images.pull_policy }}
+        {{- if .Values.resources.enabled }}
+        resources:
+          limits:
+            cpu: {{ .Values.resources.maas_rack_controller.limits.cpu | quote }}
+            memory: {{ .Values.resources.maas_rack_controller.limits.memory | quote }}
+          requests:
+            cpu: {{ .Values.resources.maas_rack_controller.requests.cpu | quote }}
+            memory: {{ .Values.resources.maas_rack_controller.requests.memory | quote }}
+        {{- end }}
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: registerrackcontrollersh
+          mountPath: "/usr/local/bin/register-rack-controller.sh"
+          subPath: "register-rack-controller.sh"
+      volumes:
+        - name: registerrackcontrollersh
+          configMap:
+            name: maas-bin
+            defaultMode: 0511

--- a/maas/templates/deploy-region.yaml
+++ b/maas/templates/deploy-region.yaml
@@ -1,0 +1,110 @@
+# Copyright 2017 The Openstack-Helm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: maas-region
+spec:
+  serviceName: "{{ .Values.ui_service_name }}"
+  template:
+    metadata:
+      labels:
+        app: maas-region
+      annotations:
+        pod.beta.kubernetes.io/init-containers: '[
+          {
+            "name": "init",
+            "image": "{{ .Values.images.maas_region }}",
+            "imagePullPolicy": "{{ .Values.images.pull_policy }}",
+            "command": ["bash", "/tmp/start.sh"],
+            "volumeMounts": [
+                {
+                    "name": "maas-config",
+                    "mountPath": "/etc/maas/"
+                },
+                {
+                    "name": "startsh",
+                    "mountPath": "/tmp/start.sh",
+                    "subPath": "start.sh"
+                },
+                {
+                    "name": "maasregionpostinst",
+                    "mountPath": "/var/lib/dpkg/info/maas-region-controller.postinst",
+                    "subPath": "maas-region-controller.postinst"
+                },
+                {
+                    "name": "postgresql-defaults",
+                    "mountPath": "/etc/dbconfig-common/maas-region-controller.conf",
+                    "subPath": "maas-region-controller.conf"
+                }
+            ]
+          }
+        ]'
+    spec:
+      nodeSelector:
+        {{ .Values.labels.node_selector_key }}: {{ .Values.labels.node_selector_value }}
+      containers:
+      - name: maas-region
+        image: {{ .Values.images.maas_region }}
+        imagePullPolicy: {{ .Values.images.pull_policy }}
+        {{- if .Values.resources.enabled }}
+        resources:
+          limits:
+            cpu: {{ .Values.resources.maas_region.limits.cpu | quote }}
+            memory: {{ .Values.resources.maas_region.limits.memory | quote }}
+          requests:
+            cpu: {{ .Values.resources.maas_region.requests.cpu | quote }}
+            memory: {{ .Values.resources.maas_region.requests.memory | quote}}
+        {{- end }}
+        ports:
+        - name: region-ui
+          containerPort: {{ .Values.network.port.region_container }}
+        readinessProbe:
+          tcpSocket:
+            port: {{ .Values.network.port.region_container }}
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: maas-lib
+          mountPath: /var/lib/maas
+        - name: maas-region-secret
+          mountPath: /var/lib/maas/secret
+          subPath: secret
+        - name: maas-dns-config
+          mountPath: /etc/bind/named.conf.options
+          subPath: named.conf.options
+        - name: maas-config
+          mountPath: /etc/maas/regiond.conf
+          subPath: regiond.conf
+      volumes:
+        - name: maas-lib
+          emptyDir: {}
+        - name: maas-region-secret
+          configMap:
+            name: maas-etc
+        - name: maas-config
+          emptyDir: {}
+        - name: maas-dns-config
+          configMap:
+            name: maas-etc
+        - name: postgresql-defaults
+          configMap:
+            name: maas-etc
+        - name: startsh
+          configMap:
+            name: maas-bin
+        - name: maasregionpostinst
+          configMap:
+            name: maas-bin

--- a/maas/templates/etc/_postgresql-config.tpl
+++ b/maas/templates/etc/_postgresql-config.tpl
@@ -1,0 +1,61 @@
+# Copyright 2017 The Openstack-Helm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# dbc_install: configure database with dbconfig-common?
+#              set to anything but "true" to opt out of assistance
+dbc_install='true'
+
+# dbc_upgrade: upgrade database with dbconfig-common?
+#              set to anything but "true" to opt out of assistance
+dbc_upgrade='true'
+
+# dbc_remove: deconfigure database with dbconfig-common?
+#             set to anything but "true" to opt out of assistance
+dbc_remove='true'
+
+# dbc_dbtype: type of underlying database to use
+#	this exists primarily to let dbconfig-common know what database
+#	type to use when a package supports multiple database types.
+#	don't change this value unless you know for certain that this
+#	package supports multiple database types
+dbc_dbtype='pgsql'
+
+# dbc_dbuser: database user
+#	the name of the user who we will use to connect to the database.
+dbc_dbuser='{{ .Values.database.db_user }}'
+
+# dbc_dbpass: database user password
+#	the password to use with the above username when connecting
+#	to a database, if one is required
+dbc_dbpass='{{ .Values.database.db_password }}'
+
+# dbc_dbname: name of database
+#	this is the name of your application's database.
+dbc_dbname='{{ .Values.database.db_name }}'
+
+# dbc_dbadmin: name of the administrative user
+#	this is the administrative user that is used to create all of the above
+#	The exception is the MySQL/MariaDB localhost case, where this value is
+#	ignored and instead is determined from /etc/mysql/debian.cnf.
+dbc_dbadmin='postgres'
+
+dbc_dbserver={{ include "helm-toolkit.postgresql_host" . | quote }}
+dbc_dbport={{ .Values.network.port.db_service }}
+
+# dbc_authmethod_admin: authentication method for admin
+# dbc_authmethod_user: authentication method for dbuser
+#	see the section titled "AUTHENTICATION METHODS" in
+#	/usr/share/doc/dbconfig-common/README.pgsql for more info
+dbc_authmethod_admin='ident'
+dbc_authmethod_user='password'

--- a/maas/templates/etc/_region-dns-config.tpl
+++ b/maas/templates/etc/_region-dns-config.tpl
@@ -1,0 +1,18 @@
+# Copyright 2017 The Openstack-Helm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+options { directory "/var/cache/bind";
+auth-nxdomain no;
+listen-on-v6 { any; };
+include "/etc/bind/maas/named.conf.options.inside.maas"; };

--- a/maas/templates/etc/_secret.tpl
+++ b/maas/templates/etc/_secret.tpl
@@ -1,0 +1,1 @@
+{{ .Values.secret }}

--- a/maas/templates/job-import.yaml
+++ b/maas/templates/job-import.yaml
@@ -1,0 +1,48 @@
+{{- $envAll := . }}
+{{- $dependencies := .Values.dependencies.import_resources }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: region-import-resources
+spec:
+  template:
+    metadata:
+      annotations:
+        pod.beta.kubernetes.io/init-containers: '[
+{{ tuple $envAll $dependencies | include "helm-toolkit.kubernetes_entrypoint_init_container" | indent 10 }}
+        ]'
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: region-import-resources
+          image: {{ .Values.images.maas_region }}
+          imagePullPolicy: {{ .Values.images.pull_policy }}
+          command:
+            - bash
+            - /tmp/import-boot-resources.sh
+          readinessProbe:
+            exec:
+              command:
+                - bash
+                - /tmp/job-readiness.sh
+            initialDelaySeconds: 60
+          volumeMounts:
+            - name: import-boot-resources
+              mountPath: /tmp/import-boot-resources.sh
+              subPath: import-boot-resources.sh
+            - name: job-readiness
+              mountPath: /tmp/job-readiness.sh
+              subPath: job-readiness.sh
+            - name: maas-dns-config
+              mountPath: /etc/bind/named.conf.options
+              subPath: named.conf.options
+      volumes:
+        - name: import-boot-resources
+          configMap:
+            name: maas-bin
+        - name: job-readiness
+          configMap:
+            name: maas-bin
+        - name: maas-dns-config
+          configMap:
+            name: maas-etc

--- a/maas/templates/maas-service.yaml
+++ b/maas/templates/maas-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.ui_service_name }}
+  labels:
+    app: maas-region-ui
+spec:
+  ports:
+  - port: {{ .Values.network.port.service_gui }}
+    targetPort: {{ .Values.network.port.service_gui_target }}
+    protocol: TCP
+    name: gui
+  - port: {{ .Values.network.port.service_proxy }}
+    targetPort: {{ .Values.network.port.service_proxy_target }}
+    protocol: TCP
+    name: proxy
+  selector:
+    app: maas-region

--- a/maas/tests/test-pxe-client.sh
+++ b/maas/tests/test-pxe-client.sh
@@ -1,0 +1,45 @@
+#!/bin/bash -x
+
+# Copyright 2017 The Openstack-Helm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# this helps create a qemu client (not using kvm acceleration
+# so it doesn't conflict with virtualbox users) that can be
+# used to test that maas is working
+
+cat <<EOF>/tmp/maas-net.xml
+<!-- Network Management VLAN -->
+<network>
+  <name>maas</name>
+  <bridge name="maas"/>
+  <forward mode="bridge"/>
+</network>
+EOF
+
+virsh net-create /tmp/maas-net.xml
+
+# purge an existing image if one exists
+if [ -e /tmp/maas-node-test.qcow2 ]; then
+  sudo rm /tmp/maas-node-test.qcow2
+  sudo qemu-img create -f qcow2 -o preallocation=metadata /tmp/maas-node-test.qcow2 32G
+fi;
+
+virt-install \
+    --name=maas-node-test \
+    --connect=qemu:///system --ram=1024 --vcpus=1 --virt-type=qemu\
+    --pxe --boot network,hd \
+    --os-variant=ubuntutrusty --graphics vnc --noautoconsole --os-type=linux --accelerate \
+    --disk=/tmp/maas-node-test.qcow2,bus=virtio,cache=none,sparse=true,size=32 \
+    --network=network=maas,model=e1000 \
+    --force

--- a/maas/values.yaml
+++ b/maas/values.yaml
@@ -1,0 +1,84 @@
+# Copyright 2017 The Openstack-Helm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Default values for maas.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+credentials:
+  admin_username: admin
+  admin_password: admin
+  admin_email: support@nowhere.com
+
+database:
+  db_name: maasdb
+  db_user: maas
+  db_password: password
+
+dependencies:
+  import_resources:
+    pod:
+    - maas-region-0
+    container:
+    - maas-region
+    service:
+    - maas-region-ui
+    - postgresql
+
+images:
+  maas_region: quay.io/attcomdev/maas-region:2.1.2-2
+  maas_rack: quay.io/attcomdev/maas-rack:2.1.2-2
+  dep_check: quay.io/stackanetes/kubernetes-entrypoint:v0.1.0
+  pull_policy: Always
+
+jobs:
+  import_boot_resources:
+    retry_timer: 10
+    #default timeout: 15 minutes
+    timeout: 900
+
+labels:
+  node_selector_key: openstack-control-plane
+  node_selector_value: enabled
+
+network:
+  port:
+    region_container: 80
+    service_gui: 80
+    service_gui_target: 80
+    service_proxy: 8000
+    service_proxy_target: 8000
+    db_service: 5432
+    db_service_target: 5432
+
+ui_service_name: maas-region-ui
+db_service_name: db-service
+secret: 3858f62230ac3c915f300c664312c63f
+
+resources:
+  enabled: false
+  maas_rack_controller:
+    limits:
+      memory: "128Mi"
+      cpu: "500m"
+    requests:
+      memory: "128Mi"
+      cpu: "500m"
+  maas_region:
+    limits:
+      memory: "128Mi"
+      cpu: "500m"
+    requests:
+      memory: "128Mi"
+      cpu: "500m"

--- a/postgresql/.helmignore
+++ b/postgresql/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/postgresql/Chart.yaml
+++ b/postgresql/Chart.yaml
@@ -1,0 +1,17 @@
+# Copyright 2017 The Openstack-Helm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+description: A Helm chart for postgresql
+name: postgresql
+version: 0.1.0

--- a/postgresql/README.md
+++ b/postgresql/README.md
@@ -1,0 +1,11 @@
+# openstack-helm/postgresql
+
+This chart leverages StatefulSets, with persistent storage.
+
+The StatefulSets all leverage PVCs to provide stateful storage to /var/lib/postgresql.
+
+You must ensure that your control nodes that should receive postgresql instances are labeled with openstack-control-plane=enabled, or whatever you have configured in values.yaml for the label configuration:
+
+```
+kubectl label nodes openstack-control-plane=enabled --all
+```

--- a/postgresql/requirements.yaml
+++ b/postgresql/requirements.yaml
@@ -1,0 +1,18 @@
+# Copyright 2017 The Openstack-Helm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+dependencies:
+  - name: helm-toolkit
+    repository: http://localhost:8879/charts
+    version: 0.1.0

--- a/postgresql/templates/deployment.yaml
+++ b/postgresql/templates/deployment.yaml
@@ -1,0 +1,68 @@
+# Copyright 2017 The Openstack-Helm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: {{ .Values.service_name }}
+spec:
+  serviceName: {{ .Values.service_name }}
+  replicas: {{ .Values.replicas }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.service_name }}
+    spec:
+      nodeSelector:
+        {{ .Values.labels.node_selector_key }}: {{ .Values.labels.node_selector_value }}
+      containers:
+      - name: {{ .Values.service_name }}
+        image: {{ .Values.images.postgresql }}
+        imagePullPolicy: {{ .Values.images.pull_policy }}
+        ports:
+        - containerPort: {{ .Values.network.port.postgresql }}
+        livenessProbe:
+          exec:
+            command:
+            - pg_isready
+          initialDelaySeconds: 20
+          timeoutSeconds: 5
+        readinessProbe:
+          exec:
+            command:
+            - pg_isready
+          initialDelaySeconds: 20
+          timeoutSeconds: 5
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        volumeMounts:
+        - name: postgresql-data
+          mountPath: /var/lib/postgresql
+      volumes:
+{{- if .Values.development.enabled }}
+      - name: postgresql-data
+        hostPath:
+          path: {{ .Values.development.storage_path }}
+{{- else }}
+  volumeClaimTemplates:
+  - metadata:
+      name: postgresql-data
+      annotations:
+        {{ .Values.volume.class_path }}: {{ .Values.volume.class_name }}
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: {{ .Values.volume.size }}
+{{- end }}

--- a/postgresql/templates/service.yaml
+++ b/postgresql/templates/service.yaml
@@ -1,0 +1,24 @@
+# Copyright 2017 The Openstack-Helm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.service_name }}
+spec:
+  ports:
+    - name: db
+      port: {{ .Values.network.port.postgresql }}
+  selector:
+    app: {{ .Values.service_name }}

--- a/postgresql/values.yaml
+++ b/postgresql/values.yaml
@@ -1,0 +1,43 @@
+# Copyright 2017 The Openstack-Helm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Default values for postgresql.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+development:
+  enabled: true
+  storage_path: /data/openstack-helm/postgresql
+
+replicas: 1 #only 1 replica currently supported
+
+service_name: postgresql
+
+# using dockerhub postgresql: https://hub.docker.com/r/library/postgres/tags/
+images:
+  postgresql: "docker.io/postgres:9.5"
+  pull_policy: IfNotPresent
+
+volume:
+  class_path: volume.beta.kubernetes.io/storage-class
+  class_name: general
+  size: 20Gi
+
+labels:
+  node_selector_key: openstack-control-plane
+  node_selector_value: enabled
+
+network:
+  port:
+    postgresql: 5432


### PR DESCRIPTION
this initial move is for the following charts:
* MaaS
* PostgreSQL

a follow-up issue will be created to replace `helm-toolkit` references with a template [`_helpers.tpl` ](https://github.com/kubernetes/helm/blob/3b9bb756bcbe0197a6c18dbe450cbb34736edf60/docs/charts_tips_and_tricks.md#using-partials-and-template-includes) file.