### PR TITLE
WIP - Kube-State-Metrics Helm Chart

### DIFF
--- a/kube-state-metrics/Chart.yaml
+++ b/kube-state-metrics/Chart.yaml
@@ -1,0 +1,22 @@
+# Copyright 2017 The Openstack-Helm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+description: Helm chart for Kube-State-Metrics
+name: kube-state-metrics
+version: 0.1.0
+home: https://github.com/kubernetes/kube-state-metrics
+sources:
+  - https://github.com/kubernetes/kube-state-metrics
+maintainers:
+  - name: OpenStack-Helm Authors

--- a/kube-state-metrics/templates/cluster-role-binding.yaml
+++ b/kube-state-metrics/templates/cluster-role-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-state-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-state-metrics
+subjects:
+- kind: ServiceAccount
+  name: kube-state-metrics
+  namespace: monitoring

--- a/kube-state-metrics/templates/cluster-role.yaml
+++ b/kube-state-metrics/templates/cluster-role.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: kube-state-metrics
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  - pods
+  - resourcequotas
+  verbs: ["list", "watch"]
+- apiGroups: ["extensions"]
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs: ["list", "watch"]

--- a/kube-state-metrics/templates/deployment.yaml
+++ b/kube-state-metrics/templates/deployment.yaml
@@ -1,0 +1,50 @@
+# Copyright 2017 The Openstack-Helm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: kube-state-metrics
+spec:
+  replicas: {{ .Values.replicas.kube_state_metrics }}
+  revisionHistoryLimit: {{ .Values.upgrades.revision_history }}
+  strategy:
+    type: {{ .Values.upgrades.pod_replacement_strategy }}
+    {{ if eq .Values.upgrades.pod_replacement_strategy "RollingUpdate" }}
+    rollingUpdate:
+      maxUnavailable: {{ .Values.upgrades.rolling_update.max_unavailable }}
+      maxSurge: {{ .Values.upgrades.rolling_update.max_surge }}
+    {{ end }}
+  template:
+    metadata:
+      labels:
+        app: kube-state-metrics
+    spec:
+      serviceAccountName: kube-state-metrics
+      containers:
+      - name: kube-state-metrics
+        image: {{ .Values.images.kube_state_metrics }}
+        imagePullPolicy: {{ .Values.images.pull_policy }}
+        ports:
+        - name: {{ .Values.network.port.target_port }}
+          containerPort: {{ .Values.network.port.port }}
+        {{ if .Values.resources.enabled }}
+        resources:
+          requests:
+            memory: {{ .Values.resources.requests.memory }}
+            cpu: {{ .Values.resources.requests.cpu }}
+          limits:
+            memory: {{ .Values.resources.limits.memory }}
+            cpu: {{ .Values.resources.limits.cpu }}
+        {{ end }}

--- a/kube-state-metrics/templates/service.yaml
+++ b/kube-state-metrics/templates/service.yaml
@@ -1,0 +1,29 @@
+# Copyright 2017 The Openstack-Helm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: kube-state-metrics
+    k8s-app: kube-state-metrics
+  name: kube-state-metrics
+spec:
+  ports:
+  - name: {{ .Values.network.port.name }}
+    port: {{ .Values.network.port.port }}
+    targetPort: {{ .Values.network.port.target_port }}
+    protocol: TCP
+  selector:
+    app: kube-state-metrics

--- a/kube-state-metrics/templates/serviceaccount.yaml
+++ b/kube-state-metrics/templates/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-state-metrics

--- a/kube-state-metrics/values.yaml
+++ b/kube-state-metrics/values.yaml
@@ -1,0 +1,42 @@
+# Copyright 2017 The Openstack-Helm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+images:
+  kube_state_metrics: quay.io/coreos/kube-state-metrics:v0.5.0
+  pull_policy: IfNotPresent
+
+network:
+  port:
+    name: http-metrics
+    port: 8080
+    target_port: metrics
+
+replicas:
+  kube_state_metrics: 1
+
+resources:
+  enabled: false
+  limits:
+    cpu: 200m
+    memory: 200Mi
+  requests:
+    cpu: 100m
+    memory: 100Mi
+
+upgrades:
+  pod_replacement_strategy: RollingUpdate
+  revision_history: 3
+  rolling_update:
+    max_surge: 3
+    max_unavailable: 1


### PR DESCRIPTION
kube-state-metrics is an agent used to expose cluster level metrics.  It operates by listening to the API server and exports metrics related to the kubernetes objects.  These metrics are exported and consumed by Prometheus, and this helm chart is leveraged by the Prometheus operator.